### PR TITLE
allow overiding the default hostname of node.name with a role attribu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the opsline-hostname cookbook.
 
+# 1.4.1
+* optional override of default node.name with `node['opsline-hostname']['hostname']`
+
 # 1.4.0
 * not using `node['cloud']['local_ipv4']`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Requirements
 
 Attributes
 ----------
+* `node['opsline-hostname']['hostname']`
+  hostname to be used instead of node name
 * `node['opsline-hostname']['domain']`
   domain to be used if node name is not FQDN
 * `node['opsline-hostname']['use_localhost_ip']`
@@ -33,11 +35,12 @@ This recipe will:
 * make hostname setting permanent
 * create entries in /etc/hosts file
 
-Hostname will be based on the node name:
-* if the nodename is a FQDN, it will be parsed to get host name and domain
-  name to set the hostname.
-* if the nodename is a not FQDN, the domain must be provided with an attribute.
-* if domain cannot be extracted from FQDN or is not provided as attribute,
+Hostname will be based on the node name or overridden `node['opsline-hostname']['hostname']` attribute:
+* if the nodename (or overridden `node['opsline-hostname']['hostname']` attribute) is a FQDN, 
+  it will be parsed to get host name and domain name to set the hostname.
+* if the nodename (or overridden `node['opsline-hostname']['hostname']` attribute) is not a FQDN, 
+  the domain must be provided with an attribute.
+* if domain cannot be extracted from FQDN or is not provided as an attribute,
   recipe will do nothing.
 * by default, hostname will be set to FQDN. Setting `use_fqdn` attribute to false
   will cause hostname to be the nodename string.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,4 @@
+default['opsline-hostname']['hostname'] = nil
 default['opsline-hostname']['domain'] = nil
 default['opsline-hostname']['use_localhost_ip'] = false
 default['opsline-hostname']['use_fqdn'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'radek@opsline.com'
 license          'All rights reserved'
 description      'Configures hostname'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.4.0'
+version          '1.4.1'
 
 supports 'redhat'
 supports 'amazon'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,6 +47,11 @@ if hostname and domain
     hostname_to_set = hostname
   end
 
+  if hostname_to_set.include?('_')
+    log "FQDN #{hostname_to_set} is invalid due to containing underscore character(s); substituting underscores with dashes"
+    hostname_to_set = hostname_to_set.gsub('_','-')
+  end
+
   Chef::Log.info("Setting hostname to #{hostname_to_set}")
 
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 #
 
 node.name =~ /^([^.]+)(\.(.+))?$/
-hostname = $1
+hostname = node['opsline-hostname']['hostname'] ? node['opsline-hostname']['hostname'] : $1
 domain = $3
 if domain.nil?
   domain = node['opsline-hostname']['domain']


### PR DESCRIPTION
…te; useful for single node stacks with chef-managed dns record
